### PR TITLE
Fix typos and errors: no crash anymore

### DIFF
--- a/spm_shoot_greens.m
+++ b/spm_shoot_greens.m
@@ -43,17 +43,17 @@ if isa(varargin{1},'char') && strcmp(varargin{1},'kernel'),
         case 0   % Circulant
             % The differential operator is symmetric, so the Fourier 
             % transform should be real
-            dtd = @(varargin) real(fft(varargin{:}));
-            dto = @(varargin) real(fft(varargin{:}));
+            dtd = @(a, dim) real(fft(a, [], dim));
+            dto = @(a, dim) real(fft(a, [], dim));
         case 1   % Neumann
-            dtd = @(varargin) dct(varargin{:}, 'Type', 1);
-            dto = @(varargin) dct(varargin{:}, 'Type', 1);
+            dtd = @(a, dim) dctr(a, dim, 'Type', 1);
+            dto = @(a, dim) dctr(a, dim, 'Type', 1);
         case 2   % Dirichlet
-            dtd = @(varargin) dst(varargin{:}, 'Type', 1);
-            dto = @(varargin) dst(varargin{:}, 'Type', 1);
+            dtd = @(a, dim) dstr(a, dim, 'Type', 1);
+            dto = @(a, dim) dstr(a, dim, 'Type', 1);
         case 3   % Sliding
-            dtd = @(varargin) dst(varargin{:}, 'Type', 1);
-            dto = @(varargin) dct(varargin{:}, 'Type', 1);
+            dtd = @(a, dim) dstr(a, dim, 'Type', 1);
+            dto = @(a, dim) dctr(a, dim, 'Type', 1);
         otherwise
             error('Boundary type %d does not exist. Should be in 0..3', bnd);
     end
@@ -61,7 +61,7 @@ if isa(varargin{1},'char') && strcmp(varargin{1},'kernel'),
     F = spm_diffeo('kernel',d,prm);
     if size(F,4) == 1 && (bnd == 0 || bnd == 1 || bnd == 2),
         % Diagonal and off-diagonal conditions are the same
-        F = dtd(dtd(dtd(F,[],1),[],2),[],3);
+        F = dtd(dtd(dtd(F,1),2),3);
         sm = numel(F);
         if nargout >=2
             ld = log(F);
@@ -82,9 +82,9 @@ if isa(varargin{1},'char') && strcmp(varargin{1},'kernel'),
             G = F;
             lat = [size(F) 1];
             F = zeros([lat(1:3) 3 3], 'like', G);
-            F(:,:,:,1,1) = dto(dto(dtd(G,[],1),[],2),[],3);
-            F(:,:,:,1,2) = dto(dtd(dto(G,[],1),[],2),[],3);
-            F(:,:,:,1,3) = dtd(dto(dto(G,[],1),[],2),[],3);
+            F(:,:,:,1,1) = dto(dto(dtd(G,1),2),3);
+            F(:,:,:,1,2) = dto(dtd(dto(G,1),2),3);
+            F(:,:,:,1,3) = dtd(dto(dto(G,1),2),3);
             clear G
             for i=2:size(F,4),
                 F(:,:,:,i,1) = F(:,:,:,1,1);
@@ -93,9 +93,9 @@ if isa(varargin{1},'char') && strcmp(varargin{1},'kernel'),
             end
         else
             for i=1:size(F,4),
-                F(:,:,:,i,1) = dto(dto(dtd(F(:,:,:,i,1),[],1),[],2),[],3);
-                F(:,:,:,i,2) = dto(dtd(dto(F(:,:,:,i,2),[],1),[],2),[],3);
-                F(:,:,:,i,3) = dtd(dto(dto(F(:,:,:,i,3),[],1),[],2),[],3);
+                F(:,:,:,i,1) = dto(dto(dtd(F(:,:,:,i,1),1),2),3);
+                F(:,:,:,i,2) = dto(dtd(dto(F(:,:,:,i,2),1),2),3);
+                F(:,:,:,i,3) = dtd(dto(dto(F(:,:,:,i,3),1),2),3);
             end
         end
         ld = 0;
@@ -107,7 +107,7 @@ if isa(varargin{1},'char') && strcmp(varargin{1},'kernel'),
                   A(:,:,:,1,2).*(A(:,:,:,2,3).*A(:,:,:,3,1) - A(:,:,:,2,1).*A(:,:,:,3,3)) +...
                   A(:,:,:,1,3).*(A(:,:,:,2,1).*A(:,:,:,3,2) - A(:,:,:,2,2).*A(:,:,:,3,1));
             msk     = dt<=0;
-            if prm(4)==0 && k==1, msk(1,1,1) = true; end;
+            if prm(4)==0 && k==1, msk(1,1,1) = true; end
             dt      = 1./dt;
             dt(msk) = 0;
             if nargout>=2
@@ -143,25 +143,25 @@ else
     end
     switch bnd
         case 0   % Circulant
-            dtd = @fft;
-            dto = @fft;
-            itd = @(varargin) ifft(varargin{:}, 'symmetric');
-            ito = @(varargin) ifft(varargin{:}, 'symmetric');
+            dtd = @(a, dim) fft(a, [], dim);
+            dto = @(a, dim) fft(a, [], dim);
+            itd = @(a, dim) ifft(a, [], dim, 'symmetric');
+            ito = @(a, dim) ifft(a, [], dim, 'symmetric');
         case 1   % Neumann
-            dtd = @(varargin) dct(varargin{:}, 'Type', 2);
-            dto = @(varargin) dct(varargin{:}, 'Type', 2);
-            itd = @(varargin) idct(varargin{:}, 'Type', 2);
-            ito = @(varargin) idct(varargin{:}, 'Type', 2);
+            dtd = @(a, dim) dctr(a, dim, 'Type', 2);
+            dto = @(a, dim) dctr(a, dim, 'Type', 2);
+            itd = @(a, dim) idctr(a, dim, 'Type', 2);
+            ito = @(a, dim) idctr(a, dim, 'Type', 2);
         case 2   % Dirichlet
-            dtd = @(varargin) dst(varargin{:}, 'Type', 2);
-            dto = @(varargin) dst(varargin{:}, 'Type', 2);
-            itd = @(varargin) idst(varargin{:}, 'Type', 2);
-            ito = @(varargin) idst(varargin{:}, 'Type', 2);
+            dtd = @(a, dim) dstr(a, dim, 'Type', 2);
+            dto = @(a, dim) dstr(a, dim, 'Type', 2);
+            itd = @(a, dim) idstr(a, dim, 'Type', 2);
+            ito = @(a, dim) idstr(a, dim, 'Type', 2);
         case 3   % Sliding
-            dtd = @(varargin) dst(varargin{:}, 'Type', 2);
-            dto = @(varargin) dct(varargin{:}, 'Type', 2);
-            itd = @(varargin) idst(varargin{:}, 'Type', 2);
-            ito = @(varargin) idct(varargin{:}, 'Type', 2);
+            dtd = @(a, dim) dstr(a, dim, 'Type', 2);
+            dto = @(a, dim) dctr(a, dim, 'Type', 2);
+            itd = @(a, dim) idstr(a, dim, 'Type', 2);
+            ito = @(a, dim) idctr(a, dim, 'Type', 2);
         otherwise
             error('Boundary type %d does not exist. Should be in 0..3', bnd);
     end
@@ -170,15 +170,15 @@ else
     if size(F,4) == 1,
         % Simple case where convolution is done one field at a time
         prm = varargin{3};
-        v(:,:,:,1) = ito(ito(itd(F.*dto(dto(dtd(m(:,:,:,1),[],1),[],2),[],3)*prm(1)^2,[],1),[],2),[],3);
-        v(:,:,:,2) = ito(itd(ito(F.*dto(dtd(dto(m(:,:,:,2),[],1),[],2),[],3)*prm(2)^2,[],1),[],2),[],3);
-        v(:,:,:,3) = itd(ito(ito(F.*dtd(dto(dto(m(:,:,:,3),[],1),[],2),[],3)*prm(3)^2,[],1),[],2),[],3);
+        v(:,:,:,1) = ito(ito(itd(F.*dto(dto(dtd(m(:,:,:,1),1),2),3)*prm(1)^2,1),2),3);
+        v(:,:,:,2) = ito(itd(ito(F.*dto(dtd(dto(m(:,:,:,2),1),2),3)*prm(2)^2,1),2),3);
+        v(:,:,:,3) = itd(ito(ito(F.*dtd(dto(dto(m(:,:,:,3),1),2),3)*prm(3)^2,1),2),3);
     else
         % More complicated case for dealing with linear elasticity, where
         % convolution is not done one field at a time
-        m(:,:,:,1) = dto(dto(dtd(m(:,:,:,1),[],1),[],2),[],3);
-        m(:,:,:,2) = dto(dtd(dto(m(:,:,:,2),[],1),[],2),[],3);
-        m(:,:,:,3) = dtd(dto(dto(m(:,:,:,3),[],1),[],2),[],3);
+        m(:,:,:,1) = dto(dto(dtd(m(:,:,:,1),1),2),3);
+        m(:,:,:,2) = dto(dtd(dto(m(:,:,:,2),1),2),3);
+        m(:,:,:,3) = dtd(dto(dto(m(:,:,:,3),1),2),3);
         for k=1:size(m,3),
             a = m(:,:,k,:);
             m(:,:,k,:) = 0;
@@ -188,11 +188,36 @@ else
                 end
             end
         end
-        v(:,:,:,1) = ito(ito(itd(m(:,:,:,1),[],1),[],2),[],3);
-        v(:,:,:,2) = ito(itd(ito(m(:,:,:,2),[],1),[],2),[],3);
-        v(:,:,:,3) = itd(ito(ito(m(:,:,:,3),[],1),[],2),[],3);
+        v(:,:,:,1) = ito(ito(itd(m(:,:,:,1),1),2),3);
+        v(:,:,:,2) = ito(itd(ito(m(:,:,:,2),1),2),3);
+        v(:,:,:,3) = itd(ito(ito(m(:,:,:,3),1),2),3);
     end
     varargout{1} = v;
 end
+
 %__________________________________________________________________________________
 
+% Robust DCT/DST that work with sices
+
+function a = dctr(a, dim, varargin)
+    if size(a, dim) > 1
+        a = dct(a, [], dim, varargin{:});
+    end
+
+
+function a = dstr(a, dim, varargin)
+    if size(a, dim) > 1
+        a = dst(a, [], dim, varargin{:});
+    end
+
+
+function a = idctr(a, dim, varargin)
+    if size(a, dim) > 1
+        a = idct(a, [], dim, varargin{:});
+    end
+
+
+function a = idstr(a, dim, varargin)
+    if size(a, dim) > 1
+        a = idst(a, [], dim, varargin{:});
+    end

--- a/src/shoot_boundary.c
+++ b/src/shoot_boundary.c
@@ -19,28 +19,28 @@ static mwSignedIndex circulant_boundary(mwSignedIndex i, mwSize m)
 }
 
 /* Neuman/Circulant boundary condition -- factor */
-static int neumann_circulant_factor(mwSignedIndex i, mwSize m, int diag)
+static float neumann_circulant_factor(mwSignedIndex i, mwSize m, int diag)
 {
-    return(1);
+    return(1.);
 }
 
 /* Dirichlet boundary condition -- factor */
-static int dirichlet_factor(mwSignedIndex i, mwSize m, int diag)
+static float dirichlet_factor(mwSignedIndex i, mwSize m, int diag)
 {
-    return(bperiod(i,m) % 2 ? -1 : 1);
+    return(bperiod(i,m) % 2 ? -1. : 1.);
 }
 
 /* Sliding (Neumann & Dirichlet) boundary condition -- factor */
-static int sliding_factor(mwSignedIndex i, mwSize m, int diag)
+static float sliding_factor(mwSignedIndex i, mwSize m, int diag)
 {
     if(diag)
-        return(bperiod(i,m) % 2 ? -1 : 1);
+        return(bperiod(i,m) % 2 ? -1. : 1.);
     else
-        return(1);
+        return(1.);
 }
 
 mwSignedIndex (*bound)()        = circulant_boundary;
-int           (*bound_factor)() = neumann_circulant_factor;
+float         (*bound_factor)() = neumann_circulant_factor;
 static int bound_type = BOUND_CIRCULANT;
 
 void set_bound(int t)

--- a/src/shoot_boundary.h
+++ b/src/shoot_boundary.h
@@ -7,7 +7,7 @@
 #define BOUND_SLIDING   3
 
 extern mwSignedIndex (*bound)();
-extern int (*bound_factor)();
+extern float (*bound_factor)();
 extern void set_bound(int t);
 extern int  get_bound();
 extern mwSignedIndex bperiod(mwSignedIndex i, mwSize m);

--- a/src/shoot_regularisers.c
+++ b/src/shoot_regularisers.c
@@ -334,7 +334,7 @@ double sumsq(mwSize dm[], float a[], float b[], double s[], float u[])
     for(k=0; k<dm[2]; k++)
     {
         mwSignedIndex j, km2,km1,kp1,kp2;
-        int fkm2, fkm1, fkp2, fkp1, gkm2, gkm1, gkp2, gkp1;
+        float fkm2, fkm1, fkp2, fkp1, gkm2, gkm1, gkp2, gkp1;
         
         km2 = (bound(k-2,dm[2])-k)*dm[0]*dm[1];
         km1 = (bound(k-1,dm[2])-k)*dm[0]*dm[1];
@@ -353,7 +353,7 @@ double sumsq(mwSize dm[], float a[], float b[], double s[], float u[])
         {
             float *pux, *puy, *puz, *pbx, *pby, *pbz, *paxx, *payy, *pazz, *paxy, *paxz, *payz;
             mwSignedIndex i, jm2,jm1,jp1,jp2;
-            int fjm2, fjm1, fjp2, fjp1, gjm2, gjm1, gjp2, gjp1;
+            float fjm2, fjm1, fjp2, fjp1, gjm2, gjm1, gjp2, gjp1;
 
             pux  = u+dm[0]*(j+dm[1]*k);
             puy  = u+dm[0]*(j+dm[1]*(k+dm[2]));
@@ -392,7 +392,7 @@ double sumsq(mwSize dm[], float a[], float b[], double s[], float u[])
             for(i=0; i<dm[0]; i++)
             {
                 mwSignedIndex im2,im1,ip1,ip2;
-                int fim1, fim2, fip1, fip2, gim1, gim2, gip1, gip2;
+                float fim1, fim2, fip1, fip2, gim1, gim2, gip1, gip2;
                 float *px = pux+i, *py = puy+i, *pz = puz+i;
                 double tmp, abx, aby, abz, c;
 
@@ -548,7 +548,7 @@ void vel2mom_le(mwSize dm[], float f[], double s[], float g[])
     for(k=0; k<dm[2]; k++)
     {
         mwSignedIndex j, km1, kp1;
-        int fkm1, fkp1, gkm1, gkp1;
+        float fkm1, fkp1, gkm1, gkp1;
         km1 = (bound(k-1,dm[2])-k)*dm[0]*dm[1]; // Wrap/mirror outside domain
         kp1 = (bound(k+1,dm[2])-k)*dm[0]*dm[1];
         fkm1 = bound_factor(k-1, dm[2], 1); // Factor if sliding/dircihlet
@@ -559,7 +559,7 @@ void vel2mom_le(mwSize dm[], float f[], double s[], float g[])
         for(j=0; j<dm[1]; j++)
         {
             mwSignedIndex i, jm1, jp1;
-            int fjm1, fjp1, gjm1, gjp1;
+            float fjm1, fjp1, gjm1, gjp1;
             float *pgx, *pgy, *pgz, *pfx, *pfy, *pfz;
 
             // Pointers to output momentum volume
@@ -582,7 +582,7 @@ void vel2mom_le(mwSize dm[], float f[], double s[], float g[])
             for(i=0; i<dm[0]; i++)
             {
                 mwSignedIndex im1, ip1;
-                int fim1, fip1, gim1, gip1;
+                float fim1, fip1, gim1, gip1;
                 float *px = &pfx[i],    //< vx(i,j,k)
                       *py = &pfy[i],    //< vy(i,j,k)
                       *pz = &pfz[i];    //< vz(i,j,k)
@@ -725,7 +725,7 @@ void relax_le(mwSize dm[], float a[], float b[], double s[], int nit, float u[])
         for(k=it&1; k<dm[2]; k+=2) // Z loop
         {
             mwSignedIndex j, km1, kp1;
-            int fkm1, fkp1, gkm1, gkp1;
+            float fkm1, fkp1, gkm1, gkp1;
             km1 = (bound(k-1,dm[2])-k)*dm[0]*dm[1];
             kp1 = (bound(k+1,dm[2])-k)*dm[0]*dm[1];
             fkm1 = bound_factor(k-1, dm[2], 1); // Factor if sliding
@@ -737,7 +737,7 @@ void relax_le(mwSize dm[], float a[], float b[], double s[], int nit, float u[])
             {
                 float *pux, *puy, *puz, *pbx, *pby, *pbz, *paxx, *payy, *pazz, *paxy, *paxz, *payz;
                 mwSignedIndex i, jm1,jp1;
-                int fjm1, fjp1, gjm1, gjp1;
+                float fjm1, fjp1, gjm1, gjp1;
 
                 // pu <- Get slice of previous guess of the solution (:,j,k)
                 pux  = u+dm[0]*(j+dm[1]* k);
@@ -763,13 +763,13 @@ void relax_le(mwSize dm[], float a[], float b[], double s[], int nit, float u[])
                 jp1 = (bound(j+1,dm[1])-j)*dm[0];
                 fjm1 = bound_factor(j-1, dm[1], 1); // Factor if sliding
                 fjp1 = bound_factor(j+1, dm[1], 1);
-                fjm1 = bound_factor(j-1, dm[1], 0);
-                fjp1 = bound_factor(j+1, dm[1], 0);
+                gjm1 = bound_factor(j-1, dm[1], 0);
+                gjp1 = bound_factor(j+1, dm[1], 0);
 
                 for(i=(it>>2)&1; i<dm[0]; i+=2) // X loop
                 {
                     mwSignedIndex im1,ip1;
-                    int fim1, fip1, gim1, gip1;
+                    float fim1, fip1, gim1, gip1;
                     double sux, suy, suz;
                     // p <- Get previous guess of the solution at (i,j,k)
                     float *px = pux+i, *py = puy+i, *pz = puz+i;
@@ -778,8 +778,8 @@ void relax_le(mwSize dm[], float a[], float b[], double s[], int nit, float u[])
                     ip1 = bound(i+1,dm[0])-i;
                     fim1 = bound_factor(i-1, dm[0], 1); // Factor if sliding
                     fip1 = bound_factor(i+1, dm[0], 1);
-                    fim1 = bound_factor(i-1, dm[0], 0);
-                    fip1 = bound_factor(i+1, dm[0], 0);
+                    gim1 = bound_factor(i-1, dm[0], 0);
+                    gip1 = bound_factor(i+1, dm[0], 0);
 
                     // su <- Get relaxation point to solve for (b - F * u)
                     sux = pbx[i] - ( wx100*(fim1*px[im1] + fip1*px[ip1])
@@ -869,7 +869,7 @@ void Atimesp_le(mwSize dm[], float A[], double param[], float p[], float Ap[])
 void vel2mom_me(mwSize dm[], float f[], double s[], float g[])
 {
     mwSignedIndex i, j, k, km1,kp1, jm1,jp1, im1,ip1;
-    int fkm1, fkp1, fjm1, fjp1, fim1, fip1, 
+    float fkm1, fkp1, fjm1, fjp1, fim1, fip1, 
         gkm1, gkp1, gjm1, gjp1, gim1, gip1;
     float *pgx, *pgy, *pgz, *pfx, *pfy, *pfz;
     double w000,w001,w010,w100;
@@ -975,7 +975,7 @@ void relax_me(mwSize dm[], float a[], float b[], double s[], int nit, float u[])
         for(k=0; k<dm[2]; k++)
         {
             mwSignedIndex km1, kp1;
-            int fkm1, fkp1, gkm1, gkp1;
+            float fkm1, fkp1, gkm1, gkp1;
             km1 = (bound(k-1,dm[2])-k)*dm[0]*dm[1];
             kp1 = (bound(k+1,dm[2])-k)*dm[0]*dm[1];
             fkm1 = bound_factor(k-1, dm[2], 1); // Factor if sliding
@@ -988,7 +988,7 @@ void relax_me(mwSize dm[], float a[], float b[], double s[], int nit, float u[])
             {
                 float *pux, *puy, *puz, *pbx, *pby, *pbz, *paxx, *paxy, *payy, *paxz, *payz, *pazz;
                 mwSignedIndex jm1,jp1, im1,ip1;
-                int fjm1, fjp1, fim1, fip1, gjm1, gjp1, gim1, gip1;
+                float fjm1, fjp1, fim1, fip1, gjm1, gjp1, gim1, gip1;
 
                 pux  = u+dm[0]*(j+dm[1]*k);
                 puy  = u+dm[0]*(j+dm[1]*(k+dm[2]));
@@ -1149,7 +1149,7 @@ void vel2mom_be(mwSize dm[], float f[], double s[], float g[])
     for(k=0; k<dm[2]; k++)
     {
         mwSignedIndex j, km2,km1,kp1,kp2;
-        int fkm1, fkm2, fkp1, fkp2, gkm1, gkm2, gkp1, gkp2;
+        float fkm1, fkm2, fkp1, fkp2, gkm1, gkm2, gkp1, gkp2;
         km2 = (bound(k-2,dm[2])-k)*dm[0]*dm[1];
         km1 = (bound(k-1,dm[2])-k)*dm[0]*dm[1];
         kp1 = (bound(k+1,dm[2])-k)*dm[0]*dm[1];
@@ -1166,7 +1166,7 @@ void vel2mom_be(mwSize dm[], float f[], double s[], float g[])
         for(j=0; j<dm[1]; j++)
         {
             mwSignedIndex i, jm2,jm1,jp1,jp2;
-            int fjm1, fjm2, fjp1, fjp2, gjm1, gjm2, gjp1, gjp2;
+            float fjm1, fjm2, fjp1, fjp2, gjm1, gjm2, gjp1, gjp2;
             float *pgx, *pgy, *pgz, *pfx, *pfy, *pfz;
 
             pgx = g+dm[0]*(j+dm[1]*k);
@@ -1193,7 +1193,7 @@ void vel2mom_be(mwSize dm[], float f[], double s[], float g[])
             for(i=0; i<dm[0]; i++)
             {
                 mwSignedIndex im2,im1,ip1,ip2;
-                int fim1, fim2, fip1, fip2, gim1, gim2, gip1, gip2;
+                float fim1, fim2, fip1, fip2, gim1, gim2, gip1, gip2;
                 float *px = &pfx[i], *py = &pfy[i], *pz = &pfz[i];
                 double c;
 
@@ -1336,7 +1336,7 @@ void relax_be(mwSize dm[], float a[], float b[], double s[], int nit, float u[])
         for(k=(it/9)%3; k<dm[2]; k+=3)
         {
             mwSignedIndex km2, km1, kp1, kp2;
-            int fkm1, fkm2, fkp1, fkp2, gkm1, gkm2, gkp1, gkp2;
+            float fkm1, fkm2, fkp1, fkp2, gkm1, gkm2, gkp1, gkp2;
             km2 = (bound(k-2,dm[2])-k)*dm[0]*dm[1];
             km1 = (bound(k-1,dm[2])-k)*dm[0]*dm[1];
             kp1 = (bound(k+1,dm[2])-k)*dm[0]*dm[1];
@@ -1354,7 +1354,7 @@ void relax_be(mwSize dm[], float a[], float b[], double s[], int nit, float u[])
             {
                 float *pux, *puy, *puz, *pbx, *pby, *pbz, *paxx, *payy, *pazz, *paxy, *paxz, *payz;
                 mwSignedIndex jm2,jm1,jp1,jp2;
-                int fjm1, fjm2, fjp1, fjp2, gjm1, gjm2, gjp1, gjp2;
+                float fjm1, fjm2, fjp1, fjp2, gjm1, gjm2, gjp1, gjp2;
 
                 pux  = u+dm[0]*(j+dm[1]* k);
                 puy  = u+dm[0]*(j+dm[1]*(k+dm[2]));
@@ -1389,7 +1389,7 @@ void relax_be(mwSize dm[], float a[], float b[], double s[], int nit, float u[])
                 for(i=it%3; i<dm[0]; i+=3)
                 {
                     mwSignedIndex im2,im1,ip1,ip2;
-                    int fim1, fim2, fip1, fip2, gim1, gim2, gip1, gip2;
+                    float fim1, fim2, fip1, fip2, gim1, gim2, gip1, gip2;
                     double sux, suy, suz, c;
                     float *px = pux+i, *py = puy+i, *pz = puz+i;
 
@@ -1567,7 +1567,7 @@ void vel2mom_all(mwSize dm[], float f[], double s[], float g[])
     for(k=0; k<dm[2]; k++)
     {
         mwSignedIndex j, km2,km1,kp1,kp2;
-        int fkm1, fkm2, fkp1, fkp2, gkm1, gkm2, gkp1, gkp2;
+        float fkm1, fkm2, fkp1, fkp2, gkm1, gkm2, gkp1, gkp2;
         km2 = (bound(k-2,dm[2])-k)*dm[0]*dm[1];
         km1 = (bound(k-1,dm[2])-k)*dm[0]*dm[1];
         kp1 = (bound(k+1,dm[2])-k)*dm[0]*dm[1];
@@ -1584,7 +1584,7 @@ void vel2mom_all(mwSize dm[], float f[], double s[], float g[])
         for(j=0; j<dm[1]; j++)
         {
             mwSignedIndex i, jm2,jm1,jp1,jp2;
-            int fjm1, fjm2, fjp1, fjp2, gjm1, gjm2, gjp1, gjp2;
+            float fjm1, fjm2, fjp1, fjp2, gjm1, gjm2, gjp1, gjp2;
             float *pgx, *pgy, *pgz, *pfx, *pfy, *pfz;
 
             pgx = g+dm[0]*(j+dm[1]*k);
@@ -1611,7 +1611,7 @@ void vel2mom_all(mwSize dm[], float f[], double s[], float g[])
             for(i=0; i<dm[0]; i++)
             {
                 mwSignedIndex im2,im1,ip1,ip2;
-                int fim1, fim2, fip1, fip2, gim1, gim2, gip1, gip2;
+                float fim1, fim2, fip1, fip2, gim1, gim2, gip1, gip2;
                 float *px = &pfx[i], *py = &pfy[i], *pz = &pfz[i];
                 double c;
 
@@ -1801,7 +1801,7 @@ void relax_all(mwSize dm[], float a[], float b[], double s[], int nit, float u[]
         for(k=(it/9)%3; k<dm[2]; k+=3)
         {
             mwSignedIndex km2, km1, kp1, kp2;
-            int fkm1, fkm2, fkp1, fkp2, gkm1, gkm2, gkp1, gkp2;
+            float fkm1, fkm2, fkp1, fkp2, gkm1, gkm2, gkp1, gkp2;
             km2 = (bound(k-2,dm[2])-k)*dm[0]*dm[1];
             km1 = (bound(k-1,dm[2])-k)*dm[0]*dm[1];
             kp1 = (bound(k+1,dm[2])-k)*dm[0]*dm[1];
@@ -1819,7 +1819,7 @@ void relax_all(mwSize dm[], float a[], float b[], double s[], int nit, float u[]
             {
                 float *pux, *puy, *puz, *pbx, *pby, *pbz, *paxx, *payy, *pazz, *paxy, *paxz, *payz;
                 mwSignedIndex jm2,jm1,jp1,jp2;
-                int fjm1, fjm2, fjp1, fjp2, gjm1, gjm2, gjp1, gjp2;
+                float fjm1, fjm2, fjp1, fjp2, gjm1, gjm2, gjp1, gjp2;
 
                 pux  = u+dm[0]*(j+dm[1]* k);
                 puy  = u+dm[0]*(j+dm[1]*(k+dm[2]));
@@ -1854,7 +1854,7 @@ void relax_all(mwSize dm[], float a[], float b[], double s[], int nit, float u[]
                 for(i=it%3; i<dm[0]; i+=3)
                 {
                     mwSignedIndex im2,im1,ip1,ip2;
-                    int fim1, fim2, fip1, fip2, gim1, gim2, gip1, gip2;
+                    float fim1, fim2, fip1, fip2, gim1, gim2, gip1, gip2;
                     double sux, suy, suz, c;
                     float *px = pux+i, *py = puy+i, *pz = puz+i;
 
@@ -1866,6 +1866,10 @@ void relax_all(mwSize dm[], float a[], float b[], double s[], int nit, float u[]
                     fim2 = bound_factor(i-2, dm[0], 1);
                     fip1 = bound_factor(i+1, dm[0], 1);
                     fip2 = bound_factor(i+2, dm[0], 1);
+                    gim1 = bound_factor(i-1, dm[0], 0);
+                    gim2 = bound_factor(i-2, dm[0], 0);
+                    gip1 = bound_factor(i+1, dm[0], 0);
+                    gip2 = bound_factor(i+2, dm[0], 0);
 
                     /* Note that a few things have been done here to reduce rounding errors.
                        This may slow things down, but it does lead to more accuracy. */


### PR DESCRIPTION
Only the DCT is available in the signal processing toolbox, so I was only able to test Neumann conditions. There is no crash anymore but PG updates overshoot a lot. I don't know if its due to bugs/errors in the code or to the fact that the Neumann boundary model is not adequate.

We will have to wait for a DST implementation to test Dirichlet and Sliding conditions.